### PR TITLE
Fix connect on browser with no api key

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -93,7 +93,7 @@ export class RealtimeAPI extends RealtimeEventHandler<
       return
     }
 
-    if (!this.apiKey) {
+    if (!this.apiKey && !isBrowser) {
       console.warn(`No apiKey provided for connection to "${this.url}"`)
     }
 


### PR DESCRIPTION
as the title suggests, fixes the connect method when on the browser and not using a dangerously set api key