### PR TITLE
fixing #4 - setting a default frequency

### DIFF
--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -31,6 +31,10 @@ export class RealtimeConversation {
     frequency?: number
     debug?: boolean
   } = {}) {
+    // Default to 24,000 Hz if not provided
+    if (frequency === undefined) {
+      frequency = this.defaultFrequency
+    }
     assert(frequency > 0, `Invalid frequency: ${frequency}`)
 
     this.frequency = frequency


### PR DESCRIPTION
If options are passed in without a frequency, the default frequency is used.