### PR TITLE
Add new voice type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export namespace Realtime {
   export type ItemStatus = 'in_progress' | 'completed' | 'incomplete'
   export type ContentPartType = 'input_text' | 'input_audio' | 'text' | 'audio'
 
-  export type Voice = 'alloy' | 'shimmer' | 'echo'
+  export type Voice = 'alloy' | 'ash' | 'ballad' | 'coral' | 'echo' | 'sage' | 'shimmer' | 'verse'
 
   export type ToolChoice =
     | 'auto'

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export namespace Realtime {
   export type ItemStatus = 'in_progress' | 'completed' | 'incomplete'
   export type ContentPartType = 'input_text' | 'input_audio' | 'text' | 'audio'
 
-  export type Voice = 'alloy' | 'ash' | 'ballad' | 'coral' | 'echo' | 'sage' | 'shimmer' | 'verse'
+  export type Voice = 'alloy' | 'ash' | 'ballad' | 'coral' | 'echo' | 'sage' | 'shimmer' | 'verse' | (string & {})
 
   export type ToolChoice =
     | 'auto'


### PR DESCRIPTION
OpenAI Realtime already has new voices on its playground. This PR adds them to the type and allows future voices without showing a TS error when the type is not ready.

![image](https://github.com/user-attachments/assets/75ab0fd7-e4a9-4b95-b64e-d87330333f9f)
