### PR TITLE
Fixing invalid URL because hostname was missing.

### DIFF
--- a/src/node/relay-server.ts
+++ b/src/node/relay-server.ts
@@ -71,7 +71,7 @@ export class RealtimeRelay {
       return
     }
 
-    const url = new URL(req.url)
+    const url = new URL(req.url, `http://${req.headers.host}`)
     const pathname = url.pathname
 
     if (pathname !== '/') {


### PR DESCRIPTION
This uses the exact line from the OpenAI repo. (Line 24 - https://github.com/openai/openai-realtime-console/blob/main/relay-server/lib/relay.js)

When trying to connect to the relay server before this fix I was getting a TypeError: Invalid URL at this line every time the client connected.